### PR TITLE
Fixing Tests to match Populist linting.

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   },
   "main": "./lib/winston-syslog",
   "scripts": {
-    "lint": "populist lib/*.js",
+    "lint": "populist **/*.js",
     "pretest": "npm run lint",
     "test": "vows test/*-test.js --spec"
   },

--- a/test/format-test.js
+++ b/test/format-test.js
@@ -1,21 +1,21 @@
 'use strict';
 
-var vows = require('vows');
-var assert = require('assert');
-var winston = require('winston');
-var dgram = require('dgram');
-var parser = require('glossy').Parse;
+const vows = require('vows');
+const assert = require('assert');
+const winston = require('winston');
+const dgram = require('dgram');
+const parser = require('glossy').Parse;
 
-var PORT = 11229;
-var server;
-var transport;
+const PORT = 11229;
+let server;
+let transport;
 
 const { MESSAGE, LEVEL } = require('triple-beam');
 
 vows.describe('syslog messages').addBatch({
   'opening fake syslog server': {
     'topic': function () {
-      var self = this;
+      const self = this;
       server = dgram.createSocket('udp4');
       server.on('listening', function () {
         self.callback();
@@ -25,7 +25,7 @@ vows.describe('syslog messages').addBatch({
     },
     'default format': {
       'topic': function () {
-        var self = this;
+        const self = this;
         server.once('message', function (msg) {
           parser.parse(msg, function (d) {
             self.callback(null, d);
@@ -45,7 +45,7 @@ vows.describe('syslog messages').addBatch({
       },
       'setting locahost option to a different falsy value (null)': {
         'topic': function () {
-          var self = this;
+          const self = this;
           server.once('message', function (msg) {
             parser.parse(msg, function (d) {
               self.callback(null, d);
@@ -67,7 +67,7 @@ vows.describe('syslog messages').addBatch({
         },
         'setting appName option to hello': {
           'topic': function () {
-            var self = this;
+            const self = this;
             server.once('message', function (msg) {
               parser.parse(msg, function (d) {
                 self.callback(null, d);
@@ -90,7 +90,7 @@ vows.describe('syslog messages').addBatch({
           },
           'setting app_name option to hello': {
             'topic': function () {
-              var self = this;
+              const self = this;
               server.once('message', function (msg) {
                 parser.parse(msg, function (d) {
                   self.callback(null, d);

--- a/test/format-test.js
+++ b/test/format-test.js
@@ -1,12 +1,10 @@
-'use strict'
+'use strict';
 
-var fs = require('fs');
 var vows = require('vows');
 var assert = require('assert');
 var winston = require('winston');
 var dgram = require('dgram');
 var parser = require('glossy').Parse;
-var Syslog = require('../lib/winston-syslog').Syslog;
 
 var PORT = 11229;
 var server;
@@ -16,7 +14,7 @@ const { MESSAGE, LEVEL } = require('triple-beam');
 
 vows.describe('syslog messages').addBatch({
   'opening fake syslog server': {
-    topic: function () {
+    'topic': function () {
       var self = this;
       server = dgram.createSocket('udp4');
       server.on('listening', function () {
@@ -26,11 +24,11 @@ vows.describe('syslog messages').addBatch({
       server.bind(PORT);
     },
     'default format': {
-      topic: function () {
+      'topic': function () {
         var self = this;
         server.once('message', function (msg) {
           parser.parse(msg, function (d) {
-            self.callback(undefined, d);
+            self.callback(null, d);
           });
         });
 
@@ -46,11 +44,11 @@ vows.describe('syslog messages').addBatch({
         transport.close();
       },
       'setting locahost option to a different falsy value (null)': {
-        topic: function () {
+        'topic': function () {
           var self = this;
           server.once('message', function (msg) {
             parser.parse(msg, function (d) {
-              self.callback(undefined, d);
+              self.callback(null, d);
             });
           });
 
@@ -68,11 +66,11 @@ vows.describe('syslog messages').addBatch({
           transport.close();
         },
         'setting appName option to hello': {
-          topic: function () {
+          'topic': function () {
             var self = this;
             server.once('message', function (msg) {
               parser.parse(msg, function (d) {
-                self.callback(undefined, d);
+                self.callback(null, d);
               });
             });
 
@@ -91,11 +89,11 @@ vows.describe('syslog messages').addBatch({
             transport.close();
           },
           'setting app_name option to hello': {
-            topic: function () {
+            'topic': function () {
               var self = this;
               server.once('message', function (msg) {
                 parser.parse(msg, function (d) {
-                  self.callback(undefined, d);
+                  self.callback(null, d);
                 });
               });
 
@@ -117,7 +115,7 @@ vows.describe('syslog messages').addBatch({
         }
       }
     },
-    teardown: function () {
+    'teardown': function () {
       server.close();
     }
   }

--- a/test/syslog-test.js
+++ b/test/syslog-test.js
@@ -1,3 +1,4 @@
+/* eslint new-cap: ["error", { "newIsCapExceptions": ["createLogger"] }] */
 /*
  * syslog-test.js: Tests for instances of the Syslog transport
  *
@@ -6,12 +7,10 @@
  *
  */
 
-var path = require('path'),
-    vows = require('vows'),
-    assert = require('assert'),
-    winston = require('winston'),
-    helpers = require('winston/test/helpers'),
-    Syslog = require('../lib/winston-syslog').Syslog;
+const vows = require('vows');
+const assert = require('assert');
+const winston = require('winston');
+const Syslog = require('../lib/winston-syslog').Syslog;
 
 function assertSyslog(transport) {
   assert.instanceOf(transport, Syslog);
@@ -20,8 +19,8 @@ function assertSyslog(transport) {
 }
 
 function closeTopicInfo() {
-  var transport = new winston.transports.Syslog(),
-      logger = new winston.createLogger({ transports: [transport] });
+  const transport = new winston.transports.Syslog();
+  const logger = new winston.createLogger({ transports: [transport] });
 
   logger.log('info', 'Test message to actually use socket');
   logger.remove(transport);
@@ -30,8 +29,8 @@ function closeTopicInfo() {
 }
 
 function closeTopicDebug() {
-  var transport = new winston.transports.Syslog(),
-      logger = new winston.createLogger({ transports: [transport] });
+  const transport = new winston.transports.Syslog();
+  const logger = new winston.createLogger({ transports: [transport] });
 
   logger.log('debug', 'Test message to actually use socket');
   logger.remove(transport);
@@ -46,7 +45,7 @@ vows.describe('winston-syslog').addBatch({
     'should have the proper methods defined': function () {
       assertSyslog(transport);
     },
-    teardown: function () {
+    'teardown': function () {
       transport.close();
     },
     'on close after not really writing': {
@@ -71,17 +70,17 @@ vows.describe('winston-syslog').addBatch({
     },
     'localhost option': {
       'should default to localhost': function () {
-        var transport = new winston.transports.Syslog();
-        assert.equal(transport.localhost, 'localhost');
-        transport.close();
+        const transportLocal = new winston.transports.Syslog();
+        assert.equal(transportLocal.localhost, 'localhost');
+        transportLocal.close();
       },
       'should accept other falsy entries as valid': function () {
-        var transport = new winston.transports.Syslog({ localhost: null });
-        assert.isNull(transport.localhost);
-        transport.close();
-        transport = new winston.transports.Syslog({ localhost: false });
-        assert.equal(transport.localhost, false);
-        transport.close();
+        let transportNotLocal = new winston.transports.Syslog({ localhost: null });
+        assert.isNull(transportNotLocal.localhost);
+        transportNotLocal.close();
+        transportNotLocal = new winston.transports.Syslog({ localhost: false });
+        assert.equal(transportNotLocal.localhost, false);
+        transportNotLocal.close();
       }
     },
     'adding / removing transport to syslog': {

--- a/test/syslog-test.js
+++ b/test/syslog-test.js
@@ -38,7 +38,7 @@ function closeTopicDebug() {
   return transport;
 }
 
-var transport = new Syslog();
+const transport = new Syslog();
 
 vows.describe('winston-syslog').addBatch({
   'An instance of the Syslog Transport': {

--- a/test/unix-connect-test.js
+++ b/test/unix-connect-test.js
@@ -1,7 +1,8 @@
+/* eslint no-sync: "off" */
+
 var fs = require('fs');
 var vows = require('vows');
 var assert = require('assert');
-var winston = require('winston');
 var unix = require('unix-dgram');
 var parser = require('glossy').Parse;
 var Syslog = require('../lib/winston-syslog').Syslog;
@@ -17,8 +18,7 @@ var transport = new Syslog({
 
 try {
   fs.unlinkSync(SOCKNAME);
-}
-catch (e) {
+} catch (e) {
   /* swallow */
 }
 
@@ -27,7 +27,7 @@ var server;
 
 vows.describe('unix-connect').addBatch({
   'Trying to log to a non-existant log server': {
-    topic: function () {
+    'topic': function () {
       var self = this;
       transport.once('error', function (err) {
         self.callback(null, err);
@@ -46,10 +46,10 @@ vows.describe('unix-connect').addBatch({
   }
 }).addBatch({
   'Logging when log server is up': {
-    topic: function () {
+    'topic': function () {
       var self = this;
       var n = 0;
-      server = unix.createSocket('unix_dgram', function (buf, rinfo) {
+      server = unix.createSocket('unix_dgram', function (buf) {
         parser.parse(buf, function (d) {
           ++n;
           assert(n <= 2);
@@ -72,7 +72,7 @@ vows.describe('unix-connect').addBatch({
   }
 }).addBatch({
   'Logging if server goes down again': {
-    topic: function () {
+    'topic': function () {
       var self = this;
       transport.once('error', function (err) {
         self.callback(null, err);
@@ -80,7 +80,7 @@ vows.describe('unix-connect').addBatch({
 
       server.close();
 
-     transport.log({ [LEVEL]: 'debug', [MESSAGE]: `data${++times}` }, function (err) {
+      transport.log({ [LEVEL]: 'debug', [MESSAGE]: `data${++times}` }, function (err) {
         assert.ifError(err);
         assert.equal(transport.queue.length, 1);
       });
@@ -93,16 +93,15 @@ vows.describe('unix-connect').addBatch({
   }
 }).addBatch({
   'Logging works if server comes up again': {
-    topic: function () {
+    'topic': function () {
       var self = this;
       var n = 2;
       try {
         fs.unlinkSync(SOCKNAME);
-      }
-      catch (e) {
+      } catch (e) {
         /* swallow */
       }
-      server = unix.createSocket('unix_dgram', function (buf, rinfo) {
+      server = unix.createSocket('unix_dgram', function (buf) {
         parser.parse(buf, function (d) {
           ++n;
           assert(n <= 4);

--- a/test/unix-connect-test.js
+++ b/test/unix-connect-test.js
@@ -1,17 +1,17 @@
 /* eslint no-sync: "off" */
 
-var fs = require('fs');
-var vows = require('vows');
-var assert = require('assert');
-var unix = require('unix-dgram');
-var parser = require('glossy').Parse;
-var Syslog = require('../lib/winston-syslog').Syslog;
+const fs = require('fs');
+const vows = require('vows');
+const assert = require('assert');
+const unix = require('unix-dgram');
+const parser = require('glossy').Parse;
+const Syslog = require('../lib/winston-syslog').Syslog;
 
 const { MESSAGE, LEVEL } = require('triple-beam');
 
-var SOCKNAME = '/tmp/unix_dgram.sock';
+const SOCKNAME = '/tmp/unix_dgram.sock';
 
-var transport = new Syslog({
+const transport = new Syslog({
   protocol: 'unix-connect',
   path: SOCKNAME
 });
@@ -22,13 +22,13 @@ try {
   /* swallow */
 }
 
-var times = 0;
-var server;
+let times = 0;
+let server;
 
 vows.describe('unix-connect').addBatch({
   'Trying to log to a non-existant log server': {
     'topic': function () {
-      var self = this;
+      const self = this;
       transport.once('error', function (err) {
         self.callback(null, err);
       });
@@ -47,8 +47,8 @@ vows.describe('unix-connect').addBatch({
 }).addBatch({
   'Logging when log server is up': {
     'topic': function () {
-      var self = this;
-      var n = 0;
+      const self = this;
+      let n = 0;
       server = unix.createSocket('unix_dgram', function (buf) {
         parser.parse(buf, function (d) {
           ++n;
@@ -73,7 +73,7 @@ vows.describe('unix-connect').addBatch({
 }).addBatch({
   'Logging if server goes down again': {
     'topic': function () {
-      var self = this;
+      const self = this;
       transport.once('error', function (err) {
         self.callback(null, err);
       });
@@ -94,8 +94,8 @@ vows.describe('unix-connect').addBatch({
 }).addBatch({
   'Logging works if server comes up again': {
     'topic': function () {
-      var self = this;
-      var n = 2;
+      const self = this;
+      let n = 2;
       try {
         fs.unlinkSync(SOCKNAME);
       } catch (e) {


### PR DESCRIPTION
Adding on to https://github.com/winstonjs/winston-syslog/pull/86 by also linting and cleaning up the tests to match the new formatting.

This work also cleans up the tests themselves, since some of them seem to have broken when Winston deprecated their testing helpers. I did have to include some overrides - I'm assuming there's no way around using the Sync methods for our socket tests, and we're definitely not going to get Winston to change `createLogger` to `CreateLogger`. I kept both overrides as minimal and scoped as possible though.

I've also changed the `npm run lint` command to lint all files, since they all pass linting now.